### PR TITLE
Update main.tf

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -79,3 +79,12 @@ module "api-alarm" {
   error_threshold  = "1"
   sns_topic_arn    = data.aws_ssm_parameter.cloudwatch_topic_arn.value
 }
+    
+module "sns-delivery-failure-alarm" {
+  source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/sns-delivery-metric-and-alarm"
+  environment_name = var.environment_name
+  region           = data.aws_region.current.name
+  account_id       = data.aws_caller_identity.current.account_id
+  sns_topic_name   = "tenure.fifo"
+  sns_topic_arn_for_notifications = data.aws_ssm_parameter.cloudwatch_topic_arn.value
+}


### PR DESCRIPTION
Add SNS delivery failure alarm
- Utilise current logs recorded when SNS messages have been delivered or have failed to be delivered
- Raise an alarm in case of failure to notify the relevant team