### PR TITLE
Update shared tenure package to 0.20.0

### DIFF
--- a/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
+++ b/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.19.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.20.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TenureInformationApi/TenureInformationApi.csproj
+++ b/TenureInformationApi/TenureInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.19.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />


### PR DESCRIPTION
## Link to JIRA ticket

[HT20-586: Move Storage to Booking page](https://hackney.atlassian.net/browse/HT20-586)
[HT20-694: Add rent adjustment editor to booking page](https://hackney.atlassian.net/browse/HT20-694)

## Describe this PR

### *What is the problem we're trying to solve*

Update shared tenure package to 0.20.0

### *What changes have we introduced*

Add separate fields to the charges object to store temporary accommodation charges.

### *Follow up actions after merging PR*

Once approved, we will need to amend the swagger documentation for the tenure API.