### PR TITLE
Update tenure shared to 0.22 to support patchable potential end date

### DIFF
--- a/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
+++ b/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.21.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.22.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TenureInformationApi/TenureInformationApi.csproj
+++ b/TenureInformationApi/TenureInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.21.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />


### PR DESCRIPTION
## Link to JIRA ticket

[HT20-732: Change tenure end date to save to potentialEndDate](https://hackney.atlassian.net/browse/HT20-732)

## Describe this PR

### *What is the problem we're trying to solve*

The Temporary Accommodation tool requires the potential end date to be added after tenure creation, as it is not always immediately known.

### *What changes have we introduced*

Add potential end date to the edit tenure details request object in tenure shared, and reference the new package