### PR TITLE
HT20-839: Update Hackney.Shared.Tenure to latest version

### DIFF
--- a/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
+++ b/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.25.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.26.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TenureInformationApi/TenureInformationApi.csproj
+++ b/TenureInformationApi/TenureInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.25.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.26.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />


### PR DESCRIPTION
## Link to JIRA ticket

[Backend: restore a historical booking 
](https://hackney.atlassian.net/browse/HT20-839)

## Describe this PR

### *What is the problem we're trying to solve*

TA officers will need to be able to restore a historical booking so that when a resident’s circumstances change, they can remain in a TA property. To do so, there needs to be a field that stores the fact that payment has (or hasn't been) suspended for that booking). This has been introduced in the [Hackney.Shared.Tenure package v 0.26.0](https://github.com/LBHackney-IT/tenure-shared/pull/26): this PR is to reference said version.

### *What changes have we introduced*
Reference to Hackney.Shared.Tenure package v 0.26.0 instead of 0.25.0