### PR TITLE
Bump "Tenure Shared" to v0.27.0 - Added "TempAccommodationInfo", namely "BookingStatus" and "AssignedOfficer".

### DIFF
--- a/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
+++ b/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.26.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.27.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TenureInformationApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/TenureInformationApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -510,12 +510,18 @@ namespace TenureInformationApi.Tests.V1.Gateways
 
             // call gateway method
             var mockQuery = new TenureQueryRequest { Id = mockTenure.Id };
-            var mockRequestObject = _fixture.Create<EditTenureDetailsRequestObject>();
+            var mockRequestObject = _fixture
+                .Build<EditTenureDetailsRequestObject>()
+                .Without(et => et.TempAccommodationInfo)
+                .Create();
+
             var mockRequestBody = "";
 
             Func<Task> act = async () =>
             {
-                await _classUnderTest.EditTenureDetails(mockQuery, mockRequestObject, mockRequestBody, expectedVersionNumber).ConfigureAwait(false);
+                await _classUnderTest
+                    .EditTenureDetails(mockQuery, mockRequestObject, mockRequestBody, expectedVersionNumber)
+                    .ConfigureAwait(false);
             };
 
             // assert exception is thrown
@@ -585,7 +591,11 @@ namespace TenureInformationApi.Tests.V1.Gateways
 
             // call gateway method
             var mockQuery = new TenureQueryRequest { Id = mockTenure.Id };
-            var mockRequestObject = _fixture.Create<EditTenureDetailsRequestObject>();
+            var mockRequestObject = _fixture
+                .Build<EditTenureDetailsRequestObject>()
+                .Without(et => et.TempAccommodationInfo)
+                .Create();
+
             var mockRequestBody = "";
 
             Func<Task> act = async () =>

--- a/TenureInformationApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/TenureInformationApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -510,10 +510,7 @@ namespace TenureInformationApi.Tests.V1.Gateways
 
             // call gateway method
             var mockQuery = new TenureQueryRequest { Id = mockTenure.Id };
-            var mockRequestObject = _fixture
-                .Build<EditTenureDetailsRequestObject>()
-                .Without(et => et.TempAccommodationInfo)
-                .Create();
+            var mockRequestObject = _fixture.Create<EditTenureDetailsRequestObject>();
 
             var mockRequestBody = "";
 
@@ -591,10 +588,7 @@ namespace TenureInformationApi.Tests.V1.Gateways
 
             // call gateway method
             var mockQuery = new TenureQueryRequest { Id = mockTenure.Id };
-            var mockRequestObject = _fixture
-                .Build<EditTenureDetailsRequestObject>()
-                .Without(et => et.TempAccommodationInfo)
-                .Create();
+            var mockRequestObject = _fixture.Create<EditTenureDetailsRequestObject>();
 
             var mockRequestBody = "";
 

--- a/TenureInformationApi/TenureInformationApi.csproj
+++ b/TenureInformationApi/TenureInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.26.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.27.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />

--- a/TenureInformationApi/V1/Gateways/TenureDynamoDbGateway.cs
+++ b/TenureInformationApi/V1/Gateways/TenureDynamoDbGateway.cs
@@ -133,6 +133,8 @@ namespace TenureInformationApi.V1.Gateways
 
 
         [LogCall]
+        // TODO: Refactor the 'EditTenureDetails' - the current implementation squashes UC and GW concerns into a GW.
+        // Validation and Decision making for which fields to update should be a UC logic, not GW!
         public async Task<UpdateEntityResult<TenureInformationDb>> EditTenureDetails(
             TenureQueryRequest query,
             EditTenureDetailsRequestObject editTenureDetailsRequestObject,

--- a/TenureInformationApi/V1/UseCase/EditTenureDetailsUseCase.cs
+++ b/TenureInformationApi/V1/UseCase/EditTenureDetailsUseCase.cs
@@ -48,6 +48,7 @@ namespace TenureInformationApi.V1.UseCase
                 await _snsGateway.Publish(tenureSnsMessage, tenureTopicArn).ConfigureAwait(false);
             }
 
+            // TODO: UseCase shouldn't be returning Response objects, this breaks the architecture.
             return result.UpdatedEntity.ToDomain().ToResponse();
         }
     }


### PR DESCRIPTION
# What:
 - Bumped the "Tenure Shared" package version from [v0.26.0](https://github.com/LBHackney-IT/tenure-shared/pull/26) to [v0.27.0](https://github.com/LBHackney-IT/tenure-shared/pull/29). This introduces a couple new optional fields into TenureInformation and [Post], [Patch] Tenure request models.

# Why:
 - We need to record and access the "Temporary Accommodation" Details such as "Booking Status" and "Assigned Officer".

# Notes:
 - Did some tweaks within the `EditTenureDetails` to prevent "Entity Updater" from falling over whilst trying to assigned a Domain level TA Info model to the Database TA Info model. In essence, in order to make use of "Entity Updater" without doing any extra changes, you'd need to have your Database layer models contain Domain level sub-models - meaning you need to introduce extra Tech Debt. We've gotten around it by applying the Entity Updater changes onto the Domain model as a target instead & then mapping the result back to Database layer just before it needs to be saved.
 - This endpoint needs refactoring as it adds UseCase level responsibilities into the Gateway method, making GW method harder to test, maintain, and reason about. So I added some reminder TODO comments to note down this tech debt.