### PR TITLE
Fix Sonar Scanner not receiving Tests Code Coverage reports.

### DIFF
--- a/TenureInformationApi.Tests/Dockerfile
+++ b/TenureInformationApi.Tests/Dockerfile
@@ -14,12 +14,21 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
-# Install and run sonar cloud scanner
+# Update the system & install java binaries (for sonar)
 RUN apt-get update && apt-get install -y openjdk-17-jdk
+# Install sonarscanner
 RUN dotnet tool install --global dotnet-sonarscanner
+# Install report generator
+RUN dotnet tool install --global dotnet-reportgenerator-globaltool
+
 ENV PATH="$PATH:/root/.dotnet/tools"
 
-RUN dotnet sonarscanner begin /k:"LBHackney-IT_tenure-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
+RUN dotnet sonarscanner begin \
+    /k:"LBHackney-IT_tenure-api" \
+    /o:"lbhackney-it" \
+    /d:sonar.host.url=https://sonarcloud.io \
+    /d:sonar.login="${SONAR_TOKEN}" \
+    /d:sonar.coverageReportPaths="coverage/SonarQube.xml"
 
 # Copy csproj and restore as distinct layers
 COPY ./TenureInformationApi.sln ./
@@ -36,5 +45,6 @@ COPY . .
 RUN dotnet build -c Release -o out TenureInformationApi/TenureInformationApi.csproj
 RUN dotnet build -c debug -o out TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
 
-CMD dotnet test
-RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
+CMD dotnet test ./TenureInformationApi.Tests/TenureInformationApi.Tests.csproj --collect:"XPlat Code Coverage" --results-directory ./coverage \
+    && reportgenerator "-reports:./coverage/*/coverage.cobertura.xml" "-targetdir:coverage" "-reporttypes:SonarQube" "-verbosity:Off" \
+    && (dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}" > /dev/null)

--- a/TenureInformationApi.Tests/Dockerfile
+++ b/TenureInformationApi.Tests/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 
 # Install and run sonar cloud scanner
 RUN apt-get update && apt-get install -y openjdk-17-jdk
-RUN dotnet tool install --global dotnet-sonarscanner --version 5.6.0
+RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 
 RUN dotnet sonarscanner begin /k:"LBHackney-IT_tenure-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"

--- a/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
+++ b/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
@@ -20,6 +20,10 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.1.13" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="3.0.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
# What:
 - Made the Tests run Dockerfile produce and send the generate code coverage report to SonarCloud.
 - Removed the version limiter from PR #108 as its no longer relevant.
 - Trim down the Dockerfile to omit redundant image build instructions.

# Why:
 - To ensure the newly introduced code has good tests coverage.
 - To ensure we have a history track record for tests coverage.
 - To stop Sonar Scan nagging about 0% tests coverage (even it's way above 0%) on every C# code changing PR raised.

# Notes:
 - Added a code coverage collection & report generation package (as sonar scanner doesn't do this by itself).
 - Hidden Sonar Scan output so that it does not obscure the tests run results.
 - Co-authored-by: Miles-Alford <miles.alford@hackney.gov.uk>