### PR TITLE
TS-1416: Update package version so that EndOfTenureDate can be the same as StartOfTenureDate 

### DIFF
--- a/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
+++ b/TenureInformationApi.Tests/TenureInformationApi.Tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.28.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.30.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TenureInformationApi.Tests/V1/Controllers/TenureInformationControllerTests.cs
+++ b/TenureInformationApi.Tests/V1/Controllers/TenureInformationControllerTests.cs
@@ -308,7 +308,7 @@ namespace TenureInformationApi.Tests.V1.Controllers
             var tenureEndDate = tenureStartDate.AddDays(-7);
 
             var mockQuery = _fixture.Create<TenureQueryRequest>();
-            var mockRequestObject = new EditTenureDetailsRequestObject { StartOfTenureDate = tenureEndDate };
+            var mockRequestObject = new EditTenureDetailsRequestObject { StartOfTenureDate = tenureStartDate, EndOfTenureDate = tenureEndDate };
 
             var numberOfErrors = _random.Next(2, 5);
             var mockValidationResult = new ValidationResult(_fixture.CreateMany<ValidationFailure>(numberOfErrors));

--- a/TenureInformationApi.Tests/V1/Helper/DateHandlingHelper.cs
+++ b/TenureInformationApi.Tests/V1/Helper/DateHandlingHelper.cs
@@ -1,0 +1,18 @@
+using System;
+using AutoFixture.Kernel;
+
+namespace TenureInformationApi.Tests.V1.Helper
+{
+    public class UtcDateTimeHelper : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            var type = request as Type;
+            if (type == typeof(DateTime))
+            {
+                return DateTime.UtcNow;
+            }
+            return new NoSpecimen();
+        }
+    }
+}

--- a/TenureInformationApi/TenureInformationApi.csproj
+++ b/TenureInformationApi/TenureInformationApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.28.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />

--- a/TenureInformationApi/V1/Gateways/TenureDynamoDbGateway.cs
+++ b/TenureInformationApi/V1/Gateways/TenureDynamoDbGateway.cs
@@ -159,14 +159,14 @@ namespace TenureInformationApi.V1.Gateways
             // if only tenureStartDate is passed, check if tenureStartDate exists in database and that it's later than the start date
             if (updateDomainWrapper.NewValues.ContainsKey("startOfTenureDate") && !updateDomainWrapper.NewValues.ContainsKey("endOfTenureDate"))
             {
-                var results = ValidateTenureStartDateIsLessThanCurrentTenureEndDate((DateTime?) updateDomainWrapper.NewValues["startOfTenureDate"], existingTenure.EndOfTenureDate);
+                var results = ValidateTenureStartDateIsLessOrEqualToCurrentTenureEndDate((DateTime?) updateDomainWrapper.NewValues["startOfTenureDate"], existingTenure.EndOfTenureDate);
                 if (!results.IsValid) throw new EditTenureInformationValidationException(results);
             }
 
             // if only tenureEndDate is passed, check that it's later than tenureStartDate
             if (updateDomainWrapper.NewValues.ContainsKey("endOfTenureDate") && !updateDomainWrapper.NewValues.ContainsKey("startOfTenureDate"))
             {
-                var results = ValidateTenureEndDateIsGreaterThanTenureStartDate((DateTime?) updateDomainWrapper.NewValues["endOfTenureDate"], existingTenure.StartOfTenureDate);
+                var results = ValidateTenureEndDateIsGreaterOrEqualToTenureStartDate((DateTime?) updateDomainWrapper.NewValues["endOfTenureDate"], existingTenure.StartOfTenureDate);
                 if (!results.IsValid) throw new EditTenureInformationValidationException(results);
             }
 
@@ -186,7 +186,7 @@ namespace TenureInformationApi.V1.Gateways
             return updateDbWrapper;
         }
 
-        private static ValidationResult ValidateTenureEndDateIsGreaterThanTenureStartDate(DateTime? tenureEndDate, DateTime? tenureStartDate)
+        private static ValidationResult ValidateTenureEndDateIsGreaterOrEqualToTenureStartDate(DateTime? tenureEndDate, DateTime? tenureStartDate)
         {
             var testObject = new TenureInformation
             {
@@ -199,7 +199,7 @@ namespace TenureInformationApi.V1.Gateways
             return validator.Validate(testObject);
         }
 
-        private static ValidationResult ValidateTenureStartDateIsLessThanCurrentTenureEndDate(DateTime? tenureStartDate, DateTime? tenureEndDate)
+        private static ValidationResult ValidateTenureStartDateIsLessOrEqualToCurrentTenureEndDate(DateTime? tenureStartDate, DateTime? tenureEndDate)
         {
             var testObject = new TenureInformation
             {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1416

## Describe this PR

### *What is the problem we're trying to solve*

BTA users (TA officers) need to be able to end a tenure on the same date it starts.
The changes have been introduced in the shared packages here: 
This PR aims to update the API to the latest version of the package




### *What changes have we introduced*

Add descriptions of what changes were made to address the problem and provide a solution.

Include any links to commits that introduce significant additions of code if they help explain the process of coming to the solution. e.g Addition of test database setup, addition of first test and production class, removal of buggy code, etc.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
