### PR TITLE
Increase timeout to 60s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,13 +270,15 @@ workflows:
       jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              only: release
       - build-and-test:
           context:
               - api-nuget-token-context
               - SonarCloud
-          filters:
-            branches:
-              only: release
+          requires:
+              - check-code-formatting
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,6 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_18.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,14 +231,51 @@ jobs:
           stage: "production"
 
 workflows:
-  check-and-deploy-development:
+  check:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
       - build-and-test:
           context:
             - api-nuget-token-context
             - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+
+  check-and-deploy-development:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: master
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          requires:
+            - check-code-formatting
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
@@ -252,16 +289,10 @@ workflows:
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
-          filters:
-            branches:
-              only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
-          filters:
-            branches:
-              only: master
   check-and-deploy-staging-and-production:
       jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,11 +150,7 @@ jobs:
       - sonarcloud/scan
       - run:
           name: build
-          command: docker-compose build tenure-information-api-test
-      - run:
-          name: Install Node.js
-          command: |
-            apt-get update && apt-get install -y nodejs
+          command: docker-compose build tenure-information-api-test           
       - run:
           name: Run tests
           command: docker-compose run tenure-information-api-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,10 @@ jobs:
           name: build
           command: docker-compose build tenure-information-api-test
       - run:
+          name: Install Node.js
+          command: |
+            apt-get update && apt-get install -y nodejs
+      - run:
           name: Run tests
           command: docker-compose run tenure-information-api-test
   assume-role-development:

--- a/TenureInformationApi.Tests/Dockerfile
+++ b/TenureInformationApi.Tests/Dockerfile
@@ -14,6 +14,8 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
+RUN apk update && apk add --no-cache nodejs
+
 # Update the system & install java binaries (for sonar)
 RUN apk update \
  && apk upgrade --no-cache \

--- a/TenureInformationApi/serverless.yml
+++ b/TenureInformationApi/serverless.yml
@@ -21,6 +21,7 @@ functions:
     name: ${self:service}-${self:provider.stage}
     handler: TenureInformationApi::TenureInformationApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
+    timeout: 60
     environment:
       TENURE_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/tenure/arn}
       EDIT_CHARGES_ALLOWED_GROUPS: ${ssm:/housing-tl/${self:provider.stage}/tenure-edit-charges-allowed-groups}


### PR DESCRIPTION
We found indiciations that a number of requests to the tenure API were failing with 502 which suggests that the lambda function is timing out - from the logs these failures ocurred just after 6 seconds which is the same as the current lambda timeout.

This PR increases the lambda timeout to 60 seconds to try and prevent these timeout errors