### PR TITLE
Disable prod DynamoDB stream

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -2,7 +2,7 @@ resource "aws_dynamodb_table" "tenureinformationapi_dynamodb_table" {
   name             = "TenureInformation"
   billing_mode     = "PAY_PER_REQUEST"
   hash_key         = "id"
-  stream_enabled   = true
+  stream_enabled   = var.stream_enabled
   stream_view_type = "NEW_AND_OLD_IMAGES"
 
   attribute {

--- a/terraform/development/variables.tf
+++ b/terraform/development/variables.tf
@@ -7,3 +7,8 @@ variable "project_name" {
   type    = string
   default = "Housing-Development"
 }
+
+variable stream_enabled {
+  type    = bool
+  default = true
+}

--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -1,8 +1,8 @@
-    resource "aws_dynamodb_table" "tenureinformationapi_dynamodb_table" {
+resource "aws_dynamodb_table" "tenureinformationapi_dynamodb_table" {
   name             = "TenureInformation"
   billing_mode     = "PAY_PER_REQUEST"
   hash_key         = "id"
-  stream_enabled   = true
+  stream_enabled   = var.stream_enabled
   stream_view_type = "NEW_AND_OLD_IMAGES"
 
   attribute {

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -7,3 +7,8 @@ variable "project_name" {
   type    = string
   default = "Housing-Production"
 }
+
+variable stream_enabled {
+  type    = bool
+  default = false
+}

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -2,7 +2,7 @@ resource "aws_dynamodb_table" "tenureinformationapi_dynamodb_table" {
   name             = "TenureInformation"
   billing_mode     = "PAY_PER_REQUEST"
   hash_key         = "id"
-  stream_enabled   = true
+  stream_enabled   = var.stream_enabled
   stream_view_type = "NEW_AND_OLD_IMAGES"
 
   attribute {

--- a/terraform/staging/variable.tf
+++ b/terraform/staging/variable.tf
@@ -7,3 +7,8 @@ variable "project_name" {
   type    = string
   default = "Housing-Staging"
 }
+
+variable stream_enabled {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
Currently, applying the prod terraform would enable the MMH to HFS sync, but this is not ready to release yet. In order to unblock the pipeline, this PR sets the stream on prod to disabled and lets it be configured by terraform vars.