### PR TITLE
Enable tenure stream (temp)

### DIFF
--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -10,5 +10,5 @@ variable "project_name" {
 
 variable stream_enabled {
   type    = bool
-  default = false
+  default = true
 }


### PR DESCRIPTION
Terraform doesn't allow creating a DynamoDB stream in a `false` enabled state, so it can be created as enabled `true` then in a following release can be switched off.

This will be safe because the listener function is not enabled.