### PR TITLE
Disable prod stream

### DIFF
--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -10,5 +10,5 @@ variable "project_name" {
 
 variable stream_enabled {
   type    = bool
-  default = true
+  default = false
 }


### PR DESCRIPTION
Deployment to prod worked, now the stream can be disabled on prod until the functionality is ready to release