### PR TITLE
Fix prod deploy

### DIFF
--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -10,5 +10,5 @@ variable "project_name" {
 
 variable stream_enabled {
   type    = bool
-  default = false
+  default = true
 }


### PR DESCRIPTION
It seems we need to create it in an enabled state on prod before we can disable it. It now errors by saying that it can't disable a stream that does not exist