### PR TITLE
Separate terraform and code on prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,6 +337,7 @@ workflows:
           filters:
             branches:
               only: release
+      # Release Terraform
       - permit-production-terraform-release:
           type: approval
           requires:
@@ -366,10 +367,11 @@ workflows:
           filters:
             branches:
               only: release
+      # Release API
       - permit-production-release:
           type: approval
           requires:
-            - terraform-apply-production
+            - deploy-to-staging
           filters:
             branches:
               only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,6 +375,10 @@ workflows:
           filters:
             branches:
               only: release
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-release
       - deploy-to-production:
           context: api-nuget-token-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,6 +383,7 @@ workflows:
           context: api-nuget-token-context
           requires:
             - assume-role-production
+            - permit-production-release
           filters:
             branches:
               only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ workflows:
       - deploy-to-production:
           context: api-nuget-token-context
           requires:
-            - permit-production-release
+            - assume-role-production
           filters:
             branches:
               only: release


### PR DESCRIPTION
Prod terraform is giving some weird error that'll probably take a while to fix, but the code should be deployed for an urgent halo call.

This splits off the permit-production-release and permit-production-terraform-release into parallel steps so that the code can be released without the terraform. Both require manual approval