### PR TITLE
Release #183, #184, #185, and #186 to staging.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,164 +255,164 @@ jobs:
           stage: "pre-production"
 
 workflows:
-  # check:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - master
-  #               - release
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - master
-  #               - release
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - master
-  #               - release
-  #     - terraform-init-and-plan-development:
-  #         requires:
-  #           - assume-role-development
-  #     - terraform-compliance-development:
-  #         requires:
-  #           - terraform-init-and-plan-development
+  check:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
 
-  # check-and-deploy-development:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud  
-  #         requires:
-  #           - check-code-formatting
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         requires:
-  #           - build-and-test
-  #     - terraform-init-and-plan-development:
-  #         requires:
-  #           - assume-role-development
-  #     - terraform-compliance-development:
-  #         requires:
-  #           - terraform-init-and-plan-development
-  #     - terraform-apply-development:
-  #         requires:
-  #           - terraform-compliance-development
-  #     - deploy-to-development:
-  #         context: api-nuget-token-context
-  #         requires:
-  #           - terraform-apply-development
-  # check-and-deploy-staging-and-production:
-  #     jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - build-and-test:
-  #         context:
-  #             - api-nuget-token-context
-  #             - SonarCloud
-  #         requires:
-  #             - check-code-formatting
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         requires:
-  #             - build-and-test
-  #         filters:
-  #            branches:
-  #              only: release
-  #     - terraform-init-and-plan-staging:
-  #         requires:
-  #           - assume-role-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-compliance-staging:
-  #         requires:
-  #           - terraform-init-and-plan-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-apply-staging:
-  #         requires:
-  #           - terraform-compliance-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - deploy-to-staging:
-  #         context: api-nuget-token-context
-  #         requires:
-  #           - terraform-apply-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     # Release Terraform
-  #     - permit-production-terraform-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #     - assume-role-production:
-  #         name: assume-role-production-terraform
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #             - permit-production-terraform-release
-  #         filters:
-  #            branches:
-  #              only: release
-  #     - terraform-init-and-plan-production:
-  #         requires:
-  #           - assume-role-production-terraform
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-compliance-production:
-  #         requires:
-  #           - terraform-init-and-plan-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-apply-production:
-  #         requires:
-  #           - terraform-compliance-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     # Release API
-  #     - permit-production-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - assume-role-production:
-  #         name: assume-role-production-api
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #             - permit-production-release
-  #     - deploy-to-production:
-  #         context: api-nuget-token-context
-  #         requires:
-  #           - assume-role-production-api
-  #         filters:
-  #           branches:
-  #             only: release
+  check-and-deploy-development:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: master
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud  
+          requires:
+            - check-code-formatting
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            - build-and-test
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+      - terraform-apply-development:
+          requires:
+            - terraform-compliance-development
+      - deploy-to-development:
+          context: api-nuget-token-context
+          requires:
+            - terraform-apply-development
+  check-and-deploy-staging-and-production:
+      jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: release
+      - build-and-test:
+          context:
+              - api-nuget-token-context
+              - SonarCloud
+          requires:
+              - check-code-formatting
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          requires:
+              - build-and-test
+          filters:
+             branches:
+               only: release
+      - terraform-init-and-plan-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: release
+      - terraform-compliance-staging:
+          requires:
+            - terraform-init-and-plan-staging
+          filters:
+            branches:
+              only: release
+      - terraform-apply-staging:
+          requires:
+            - terraform-compliance-staging
+          filters:
+            branches:
+              only: release
+      - deploy-to-staging:
+          context: api-nuget-token-context
+          requires:
+            - terraform-apply-staging
+          filters:
+            branches:
+              only: release
+      # Release Terraform
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+      - assume-role-production:
+          name: assume-role-production-terraform
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-terraform-release
+          filters:
+             branches:
+               only: release
+      - terraform-init-and-plan-production:
+          requires:
+            - assume-role-production-terraform
+          filters:
+            branches:
+              only: release
+      - terraform-compliance-production:
+          requires:
+            - terraform-init-and-plan-production
+          filters:
+            branches:
+              only: release
+      - terraform-apply-production:
+          requires:
+            - terraform-compliance-production
+          filters:
+            branches:
+              only: release
+      # Release API
+      - permit-production-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: release
+      - assume-role-production:
+          name: assume-role-production-api
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-release
+      - deploy-to-production:
+          context: api-nuget-token-context
+          requires:
+            - assume-role-production-api
+          filters:
+            branches:
+              only: release
 
   deploy-terraform-pre-production:
     jobs:
@@ -420,63 +420,56 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - permit-pre-production-terraform-workflow
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - terraform-init-and-plan-pre-production:
           requires:
             - assume-role-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - terraform-compliance-pre-production:
           requires:
             - terraform-init-and-plan-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - permit-pre-production-terraform-deployment:
           type: approval
           requires:
             - terraform-compliance-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - terraform-apply-pre-production:
           requires:
             - permit-pre-production-terraform-deployment
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
 
   deploy-code-pre-production:
     jobs:
-      - permit-pre-production-code-workflow:
-          type: approval
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflows
       - build-and-test:
-          requires:
-            - permit-pre-production-code-workflow
           context: 
             - api-nuget-token-context
             - SonarCloud
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - deploy-to-pre-production:
           context:
           - api-nuget-token-context
@@ -484,4 +477,4 @@ workflows:
             - assume-role-pre-production        
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ workflows:
   #           branches:
   #             only: release
 
-deploy-terraform-pre-production:
+  deploy-terraform-pre-production:
     jobs:
       - permit-pre-production-terraform-workflow:
           type: approval
@@ -454,7 +454,7 @@ deploy-terraform-pre-production:
             branches:
               only: ts-2045-add-pre-production-workflows
 
-deploy-code-pre-production:
+  deploy-code-pre-production:
     jobs:
       - permit-pre-production-code-workflow:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,164 +255,164 @@ jobs:
           stage: "pre-production"
 
 workflows:
-  # check:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - master
-  #               - release
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - master
-  #               - release
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - master
-  #               - release
-  #     - terraform-init-and-plan-development:
-  #         requires:
-  #           - assume-role-development
-  #     - terraform-compliance-development:
-  #         requires:
-  #           - terraform-init-and-plan-development
+  check:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
 
-  # check-and-deploy-development:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud  
-  #         requires:
-  #           - check-code-formatting
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         requires:
-  #           - build-and-test
-  #     - terraform-init-and-plan-development:
-  #         requires:
-  #           - assume-role-development
-  #     - terraform-compliance-development:
-  #         requires:
-  #           - terraform-init-and-plan-development
-  #     - terraform-apply-development:
-  #         requires:
-  #           - terraform-compliance-development
-  #     - deploy-to-development:
-  #         context: api-nuget-token-context
-  #         requires:
-  #           - terraform-apply-development
-  # check-and-deploy-staging-and-production:
-  #     jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - build-and-test:
-  #         context:
-  #             - api-nuget-token-context
-  #             - SonarCloud
-  #         requires:
-  #             - check-code-formatting
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         requires:
-  #             - build-and-test
-  #         filters:
-  #            branches:
-  #              only: release
-  #     - terraform-init-and-plan-staging:
-  #         requires:
-  #           - assume-role-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-compliance-staging:
-  #         requires:
-  #           - terraform-init-and-plan-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-apply-staging:
-  #         requires:
-  #           - terraform-compliance-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - deploy-to-staging:
-  #         context: api-nuget-token-context
-  #         requires:
-  #           - terraform-apply-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     # Release Terraform
-  #     - permit-production-terraform-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #     - assume-role-production:
-  #         name: assume-role-production-terraform
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #             - permit-production-terraform-release
-  #         filters:
-  #            branches:
-  #              only: release
-  #     - terraform-init-and-plan-production:
-  #         requires:
-  #           - assume-role-production-terraform
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-compliance-production:
-  #         requires:
-  #           - terraform-init-and-plan-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-apply-production:
-  #         requires:
-  #           - terraform-compliance-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     # Release API
-  #     - permit-production-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - assume-role-production:
-  #         name: assume-role-production-api
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #             - permit-production-release
-  #     - deploy-to-production:
-  #         context: api-nuget-token-context
-  #         requires:
-  #           - assume-role-production-api
-  #         filters:
-  #           branches:
-  #             only: release
+  check-and-deploy-development:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: master
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud  
+          requires:
+            - check-code-formatting
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            - build-and-test
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+      - terraform-apply-development:
+          requires:
+            - terraform-compliance-development
+      - deploy-to-development:
+          context: api-nuget-token-context
+          requires:
+            - terraform-apply-development
+  check-and-deploy-staging-and-production:
+      jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: release
+      - build-and-test:
+          context:
+              - api-nuget-token-context
+              - SonarCloud
+          requires:
+              - check-code-formatting
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          requires:
+              - build-and-test
+          filters:
+             branches:
+               only: release
+      - terraform-init-and-plan-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: release
+      - terraform-compliance-staging:
+          requires:
+            - terraform-init-and-plan-staging
+          filters:
+            branches:
+              only: release
+      - terraform-apply-staging:
+          requires:
+            - terraform-compliance-staging
+          filters:
+            branches:
+              only: release
+      - deploy-to-staging:
+          context: api-nuget-token-context
+          requires:
+            - terraform-apply-staging
+          filters:
+            branches:
+              only: release
+      # Release Terraform
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+      - assume-role-production:
+          name: assume-role-production-terraform
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-terraform-release
+          filters:
+             branches:
+               only: release
+      - terraform-init-and-plan-production:
+          requires:
+            - assume-role-production-terraform
+          filters:
+            branches:
+              only: release
+      - terraform-compliance-production:
+          requires:
+            - terraform-init-and-plan-production
+          filters:
+            branches:
+              only: release
+      - terraform-apply-production:
+          requires:
+            - terraform-compliance-production
+          filters:
+            branches:
+              only: release
+      # Release API
+      - permit-production-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: release
+      - assume-role-production:
+          name: assume-role-production-api
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-release
+      - deploy-to-production:
+          context: api-nuget-token-context
+          requires:
+            - assume-role-production-api
+          filters:
+            branches:
+              only: release
 
   deploy-terraform-pre-production:
     jobs:
@@ -420,7 +420,7 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2145-move-lambda-to-new-security-group
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
@@ -447,7 +447,7 @@ workflows:
             - SonarCloud
           filters:
             branches:
-              only: ts-2145-move-lambda-to-new-security-group
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,163 +228,260 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "production"
+  assume-role-pre-production:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_PRE_PRODUCTION
+  terraform-init-and-plan-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
+          environment: "pre-production"
+  terraform-compliance-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-compliance:
+          environment: "pre-production"
+  terraform-apply-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-apply:
+          environment: "pre-production"
+  deploy-to-pre-production:
+    executor: docker-dotnet
+    steps:
+      - deploy-lambda:
+          stage: "pre-production"
 
 workflows:
-  check:
+  # check:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - release
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - release
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - release
+  #     - terraform-init-and-plan-development:
+  #         requires:
+  #           - assume-role-development
+  #     - terraform-compliance-development:
+  #         requires:
+  #           - terraform-init-and-plan-development
+
+  # check-and-deploy-development:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud  
+  #         requires:
+  #           - check-code-formatting
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         requires:
+  #           - build-and-test
+  #     - terraform-init-and-plan-development:
+  #         requires:
+  #           - assume-role-development
+  #     - terraform-compliance-development:
+  #         requires:
+  #           - terraform-init-and-plan-development
+  #     - terraform-apply-development:
+  #         requires:
+  #           - terraform-compliance-development
+  #     - deploy-to-development:
+  #         context: api-nuget-token-context
+  #         requires:
+  #           - terraform-apply-development
+  # check-and-deploy-staging-and-production:
+  #     jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - build-and-test:
+  #         context:
+  #             - api-nuget-token-context
+  #             - SonarCloud
+  #         requires:
+  #             - check-code-formatting
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         requires:
+  #             - build-and-test
+  #         filters:
+  #            branches:
+  #              only: release
+  #     - terraform-init-and-plan-staging:
+  #         requires:
+  #           - assume-role-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-compliance-staging:
+  #         requires:
+  #           - terraform-init-and-plan-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-apply-staging:
+  #         requires:
+  #           - terraform-compliance-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - deploy-to-staging:
+  #         context: api-nuget-token-context
+  #         requires:
+  #           - terraform-apply-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     # Release Terraform
+  #     - permit-production-terraform-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #     - assume-role-production:
+  #         name: assume-role-production-terraform
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #             - permit-production-terraform-release
+  #         filters:
+  #            branches:
+  #              only: release
+  #     - terraform-init-and-plan-production:
+  #         requires:
+  #           - assume-role-production-terraform
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-compliance-production:
+  #         requires:
+  #           - terraform-init-and-plan-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-apply-production:
+  #         requires:
+  #           - terraform-compliance-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     # Release API
+  #     - permit-production-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - assume-role-production:
+  #         name: assume-role-production-api
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #             - permit-production-release
+  #     - deploy-to-production:
+  #         context: api-nuget-token-context
+  #         requires:
+  #           - assume-role-production-api
+  #         filters:
+  #           branches:
+  #             only: release
+
+deploy-terraform-pre-production:
     jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
+      - permit-pre-production-terraform-workflow:
+          type: approval
           filters:
             branches:
-              ignore:
-                - master
-                - release
+              only: ts-2045-add-pre-production-workflows
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
+          requires:
+            - permit-pre-production-terraform-workflow
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-init-and-plan-pre-production:
+          requires:
+            - assume-role-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-compliance-pre-production:
+          requires:
+            - terraform-init-and-plan-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - permit-pre-production-terraform-deployment:
+          type: approval
+          requires:
+            - terraform-compliance-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-apply-pre-production:
+          requires:
+            - permit-pre-production-terraform-deployment
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+
+deploy-code-pre-production:
+    jobs:
+      - permit-pre-production-code-workflow:
+          type: approval
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
       - build-and-test:
-          context:
+          requires:
+            - permit-pre-production-code-workflow
+          context: 
             - api-nuget-token-context
             - SonarCloud
           filters:
             branches:
-              ignore:
-                - master
-                - release
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          filters:
-            branches:
-              ignore:
-                - master
-                - release
-      - terraform-init-and-plan-development:
-          requires:
-            - assume-role-development
-      - terraform-compliance-development:
-          requires:
-            - terraform-init-and-plan-development
-
-  check-and-deploy-development:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: master
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud  
-          requires:
-            - check-code-formatting
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
+              only: ts-2045-add-pre-production-workflows
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
-      - terraform-init-and-plan-development:
-          requires:
-            - assume-role-development
-      - terraform-compliance-development:
-          requires:
-            - terraform-init-and-plan-development
-      - terraform-apply-development:
-          requires:
-            - terraform-compliance-development
-      - deploy-to-development:
-          context: api-nuget-token-context
-          requires:
-            - terraform-apply-development
-  check-and-deploy-staging-and-production:
-      jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
           filters:
             branches:
-              only: release
-      - build-and-test:
+              only: ts-2045-add-pre-production-workflows
+      - deploy-to-pre-production:
           context:
-              - api-nuget-token-context
-              - SonarCloud
+          - api-nuget-token-context
           requires:
-              - check-code-formatting
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          requires:
-              - build-and-test
-          filters:
-             branches:
-               only: release
-      - terraform-init-and-plan-staging:
-          requires:
-            - assume-role-staging
+            - assume-role-pre-production        
           filters:
             branches:
-              only: release
-      - terraform-compliance-staging:
-          requires:
-            - terraform-init-and-plan-staging
-          filters:
-            branches:
-              only: release
-      - terraform-apply-staging:
-          requires:
-            - terraform-compliance-staging
-          filters:
-            branches:
-              only: release
-      - deploy-to-staging:
-          context: api-nuget-token-context
-          requires:
-            - terraform-apply-staging
-          filters:
-            branches:
-              only: release
-      # Release Terraform
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-      - assume-role-production:
-          name: assume-role-production-terraform
-          context: api-assume-role-housing-production-context
-          requires:
-              - permit-production-terraform-release
-          filters:
-             branches:
-               only: release
-      - terraform-init-and-plan-production:
-          requires:
-            - assume-role-production-terraform
-          filters:
-            branches:
-              only: release
-      - terraform-compliance-production:
-          requires:
-            - terraform-init-and-plan-production
-          filters:
-            branches:
-              only: release
-      - terraform-apply-production:
-          requires:
-            - terraform-compliance-production
-          filters:
-            branches:
-              only: release
-      # Release API
-      - permit-production-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: release
-      - assume-role-production:
-          name: assume-role-production-api
-          context: api-assume-role-housing-production-context
-          requires:
-              - permit-production-release
-      - deploy-to-production:
-          context: api-nuget-token-context
-          requires:
-            - assume-role-production-api
-          filters:
-            branches:
-              only: release
+              only: ts-2045-add-pre-production-workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,164 +255,164 @@ jobs:
           stage: "pre-production"
 
 workflows:
-  check:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              ignore:
-                - master
-                - release
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud
-          filters:
-            branches:
-              ignore:
-                - master
-                - release
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          filters:
-            branches:
-              ignore:
-                - master
-                - release
-      - terraform-init-and-plan-development:
-          requires:
-            - assume-role-development
-      - terraform-compliance-development:
-          requires:
-            - terraform-init-and-plan-development
+  # check:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - release
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - release
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - release
+  #     - terraform-init-and-plan-development:
+  #         requires:
+  #           - assume-role-development
+  #     - terraform-compliance-development:
+  #         requires:
+  #           - terraform-init-and-plan-development
 
-  check-and-deploy-development:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: master
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud  
-          requires:
-            - check-code-formatting
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          requires:
-            - build-and-test
-      - terraform-init-and-plan-development:
-          requires:
-            - assume-role-development
-      - terraform-compliance-development:
-          requires:
-            - terraform-init-and-plan-development
-      - terraform-apply-development:
-          requires:
-            - terraform-compliance-development
-      - deploy-to-development:
-          context: api-nuget-token-context
-          requires:
-            - terraform-apply-development
-  check-and-deploy-staging-and-production:
-      jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: release
-      - build-and-test:
-          context:
-              - api-nuget-token-context
-              - SonarCloud
-          requires:
-              - check-code-formatting
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          requires:
-              - build-and-test
-          filters:
-             branches:
-               only: release
-      - terraform-init-and-plan-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: release
-      - terraform-compliance-staging:
-          requires:
-            - terraform-init-and-plan-staging
-          filters:
-            branches:
-              only: release
-      - terraform-apply-staging:
-          requires:
-            - terraform-compliance-staging
-          filters:
-            branches:
-              only: release
-      - deploy-to-staging:
-          context: api-nuget-token-context
-          requires:
-            - terraform-apply-staging
-          filters:
-            branches:
-              only: release
-      # Release Terraform
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-      - assume-role-production:
-          name: assume-role-production-terraform
-          context: api-assume-role-housing-production-context
-          requires:
-              - permit-production-terraform-release
-          filters:
-             branches:
-               only: release
-      - terraform-init-and-plan-production:
-          requires:
-            - assume-role-production-terraform
-          filters:
-            branches:
-              only: release
-      - terraform-compliance-production:
-          requires:
-            - terraform-init-and-plan-production
-          filters:
-            branches:
-              only: release
-      - terraform-apply-production:
-          requires:
-            - terraform-compliance-production
-          filters:
-            branches:
-              only: release
-      # Release API
-      - permit-production-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: release
-      - assume-role-production:
-          name: assume-role-production-api
-          context: api-assume-role-housing-production-context
-          requires:
-              - permit-production-release
-      - deploy-to-production:
-          context: api-nuget-token-context
-          requires:
-            - assume-role-production-api
-          filters:
-            branches:
-              only: release
+  # check-and-deploy-development:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud  
+  #         requires:
+  #           - check-code-formatting
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         requires:
+  #           - build-and-test
+  #     - terraform-init-and-plan-development:
+  #         requires:
+  #           - assume-role-development
+  #     - terraform-compliance-development:
+  #         requires:
+  #           - terraform-init-and-plan-development
+  #     - terraform-apply-development:
+  #         requires:
+  #           - terraform-compliance-development
+  #     - deploy-to-development:
+  #         context: api-nuget-token-context
+  #         requires:
+  #           - terraform-apply-development
+  # check-and-deploy-staging-and-production:
+  #     jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - build-and-test:
+  #         context:
+  #             - api-nuget-token-context
+  #             - SonarCloud
+  #         requires:
+  #             - check-code-formatting
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         requires:
+  #             - build-and-test
+  #         filters:
+  #            branches:
+  #              only: release
+  #     - terraform-init-and-plan-staging:
+  #         requires:
+  #           - assume-role-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-compliance-staging:
+  #         requires:
+  #           - terraform-init-and-plan-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-apply-staging:
+  #         requires:
+  #           - terraform-compliance-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - deploy-to-staging:
+  #         context: api-nuget-token-context
+  #         requires:
+  #           - terraform-apply-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     # Release Terraform
+  #     - permit-production-terraform-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #     - assume-role-production:
+  #         name: assume-role-production-terraform
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #             - permit-production-terraform-release
+  #         filters:
+  #            branches:
+  #              only: release
+  #     - terraform-init-and-plan-production:
+  #         requires:
+  #           - assume-role-production-terraform
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-compliance-production:
+  #         requires:
+  #           - terraform-init-and-plan-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-apply-production:
+  #         requires:
+  #           - terraform-compliance-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     # Release API
+  #     - permit-production-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - assume-role-production:
+  #         name: assume-role-production-api
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #             - permit-production-release
+  #     - deploy-to-production:
+  #         context: api-nuget-token-context
+  #         requires:
+  #           - assume-role-production-api
+  #         filters:
+  #           branches:
+  #             only: release
 
   deploy-terraform-pre-production:
     jobs:
@@ -420,39 +420,24 @@ workflows:
           type: approval
           filters:
             branches:
-              only: release
+              only: ts-2145-move-lambda-to-new-security-group
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - permit-pre-production-terraform-workflow
-          filters:
-            branches:
-              only: release
       - terraform-init-and-plan-pre-production:
           requires:
             - assume-role-pre-production
-          filters:
-            branches:
-              only: release
       - terraform-compliance-pre-production:
           requires:
             - terraform-init-and-plan-pre-production
-          filters:
-            branches:
-              only: release
       - permit-pre-production-terraform-deployment:
           type: approval
           requires:
             - terraform-compliance-pre-production
-          filters:
-            branches:
-              only: release
       - terraform-apply-pre-production:
           requires:
             - permit-pre-production-terraform-deployment
-          filters:
-            branches:
-              only: release
 
   deploy-code-pre-production:
     jobs:
@@ -462,19 +447,13 @@ workflows:
             - SonarCloud
           filters:
             branches:
-              only: release
+              only: ts-2145-move-lambda-to-new-security-group
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
-          filters:
-            branches:
-              only: release
       - deploy-to-pre-production:
           context:
           - api-nuget-token-context
           requires:
             - assume-role-pre-production        
-          filters:
-            branches:
-              only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,8 @@ jobs:
   build-and-test:
     executor: docker-python
     steps:
-      - checkout
+      - checkout:
+          method: full
       - setup_remote_docker
       - sonarcloud/scan
       - run:

--- a/TenureInformationApi/TenureInformationApi.csproj
+++ b/TenureInformationApi/TenureInformationApi.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.63.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.49.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />

--- a/TenureInformationApi/serverless.yml
+++ b/TenureInformationApi/serverless.yml
@@ -96,15 +96,6 @@ resources:
                           - Ref: 'AWS::Region'
                           - Ref: 'AWS::AccountId'
                           - 'log-group:/aws/lambda/*:*:*'
-                - Effect: "Allow"
-                  Action:
-                    - "s3:PutObject"
-                    - "s3:GetObject"
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - "arn:aws:s3:::"
-                        - "Ref": "ServerlessDeploymentBucket"
           - PolicyName: lambdaInvocation
             PolicyDocument:
               Version: '2012-10-17'
@@ -161,6 +152,7 @@ custom:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew
   safeguards:
     - title: Require authorizer
       safeguard: require-authorizer
@@ -181,3 +173,7 @@ custom:
       subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34
+    pre-production:
+      subnetIds:
+        - subnet-08aa35159a8706faa
+        - subnet-0b848c5b14f841dfb

--- a/TenureInformationApi/serverless.yml
+++ b/TenureInformationApi/serverless.yml
@@ -174,6 +174,8 @@ custom:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34
     pre-production:
+      securityGroupIds:
+        - sg-03d268eb8465879f4
       subnetIds:
         - subnet-08aa35159a8706faa
         - subnet-0b848c5b14f841dfb

--- a/TenureInformationApi/serverless.yml
+++ b/TenureInformationApi/serverless.yml
@@ -149,7 +149,7 @@ resources:
                           - 'table/TenureInformation'
 custom:
   authorizerArns:
-    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
     pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew

--- a/terraform/pre-production/aws_security_group.tf
+++ b/terraform/pre-production/aws_security_group.tf
@@ -3,6 +3,7 @@ data "aws_vpc" "pre_production_vpc" {
     Name = "housing-pre-prod-pre-prod"
   }
 }
+
 resource "aws_security_group" "lambda" {
   name                   = "tenure-information-api-lambda-sg"
   description            = "Security group used by the tenure API lambda function"

--- a/terraform/pre-production/aws_security_group.tf
+++ b/terraform/pre-production/aws_security_group.tf
@@ -1,0 +1,21 @@
+data "aws_vpc" "pre_production_vpc" {
+  tags = {
+    Name = "housing-pre-prod-pre-prod"
+  }
+}
+resource "aws_security_group" "lambda" {
+  name                   = "tenure-information-api-lambda-sg"
+  description            = "Security group used by the tenure API lambda function"
+  vpc_id                 = data.aws_vpc.pre_production_vpc.id
+  revoke_rules_on_delete = true
+}
+
+resource "aws_security_group_rule" "egress_https" {
+  security_group_id = aws_security_group.lambda.id
+  type              = "egress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow egress on port 443"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "TCP"
+}

--- a/terraform/pre-production/aws_ssm_parameter.tf
+++ b/terraform/pre-production/aws_ssm_parameter.tf
@@ -1,0 +1,11 @@
+resource "aws_ssm_parameter" "tenure_edit_charges_allowed_groups" {
+  name  = "/housing-tl/pre-production/tenure-edit-charges-allowed-groups"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/terraform/pre-production/dynamodb.tf
+++ b/terraform/pre-production/dynamodb.tf
@@ -1,0 +1,19 @@
+resource "aws_dynamodb_table" "tenureinformationapi_dynamodb_table" {
+  name         = "TenureInformation"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  tags = merge(
+    local.default_tags,
+    { BackupPolicy = "Dev", Backup = false, Confidentiality = "Internal" }
+  )
+
+  point_in_time_recovery {
+    enabled = false
+  }
+}

--- a/terraform/pre-production/maint.tf
+++ b/terraform/pre-production/maint.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+locals {
+  default_tags = {
+    Name              = "tenure-information-api-${var.environment_name}"
+    Environment       = var.environment_name
+    terraform-managed = true
+    project_name      = var.project_name
+    Application       = "MTFH Housing Pre-Production"
+    TeamEmail         = "developementteam@hackney.gov.uk"
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "housing-pre-production-terraform-state"
+    encrypt        = true
+    region         = "eu-west-2"
+    key            = "services/tenure-information-api/state"
+    dynamodb_table = "housing-pre-production-terraform-state-lock"
+  }
+}
+
+resource "aws_sns_topic" "tenure" {
+  name                        = "tenure.fifo"
+  fifo_topic                  = true
+  content_based_deduplication = true
+  kms_master_key_id           = "alias/aws/sns"
+}
+
+resource "aws_ssm_parameter" "tenure_sns_arn" {
+  name  = "/sns-topic/pre-production/tenure/arn"
+  type  = "String"
+  value = aws_sns_topic.tenure.arn
+}

--- a/terraform/pre-production/maint.tf
+++ b/terraform/pre-production/maint.tf
@@ -7,6 +7,10 @@ terraform {
   }
 }
 
+provider "aws" {
+  region = "eu-west-2"
+}
+
 locals {
   default_tags = {
     Name              = "tenure-information-api-${var.environment_name}"

--- a/terraform/pre-production/terraform-compliance/dynamodb.feature
+++ b/terraform/pre-production/terraform-compliance/dynamodb.feature
@@ -1,0 +1,26 @@
+Feature: DynamoDB is used as our NoSQL database service
+  In order to improve security
+  As engineers
+  We'll use ensure our DynamoDB tables are configured correctly
+
+  Scenario: Ensure BackupPolicy tag is present
+    Given I have aws_dynamodb_table defined
+    Then it must contain tags
+    And it must contain BackupPolicy
+
+  Scenario: Ensure point in time recovery disabled
+    Given I have aws_dynamodb_table defined
+    Then it must contain point_in_time_recovery
+    And its enabled property must be false
+
+  Scenario: Ensure a maximum of 1 LSIs
+    Given I have aws_dynamodb_table defined
+    When it contains local_secondary_index
+    When I count them
+    Then I expect the result is less and equal to 1
+
+  Scenario: Ensure a maximum of 2 GSIs
+    Given I have aws_dynamodb_table defined
+    When it contains global_secondary_index
+    When I count them
+    Then I expect the result is less and equal to 2

--- a/terraform/pre-production/terraform-compliance/sns.feature
+++ b/terraform/pre-production/terraform-compliance/sns.feature
@@ -1,0 +1,8 @@
+Feature: SNS is used as our notification service
+  In order to improve security
+  As engineers
+  We'll use ensure our SNS topics are configured correctly
+
+  Scenario: Ensure encryption is enabled
+    Given I have aws_sns_topic defined
+    Then it must contain kms_master_key_id

--- a/terraform/pre-production/variables.tf
+++ b/terraform/pre-production/variables.tf
@@ -1,0 +1,9 @@
+variable "environment_name" {
+  type    = string
+  default = "pre-prod"
+}
+
+variable "project_name" {
+  type    = string
+  default = "Housing-Pre-Production"
+}


### PR DESCRIPTION
# What:
 - Release #183 _(does not affect staging or prod)_.
 - Release #184 _(tighter networking, plus gets rid of serverless warnings)_.
 - Release #185 _(does not have an effect past development)_.
 - Release #186 _(release target)_.

# Why:
 - Preparation to release of cognito flow. Need to ensure the API is able to handle both token schemas.

# Notes:
 - The pre-production changes are part of cancelled work of Temporary Accomodation release. SSI team is still waiting on bureaucracy to give orders to decommission the application _(once that is done these changes can be removed)_.